### PR TITLE
[Fix] Add Monitor Server Performance Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ Folder structure should as follow:
 - deployment files
 
 ## Guide:
+#### Add Readonly ILO/IDRAC Account (IMPORTANT)
+You need to define a readonly account on ILO/IDRAC, We will use this account for collecting data (on sample.yml file or somewhere like that):
+* Example:
+
+  ```
+  cat sample.yml
+
+  Auth:
+  Username: readonly
+  Password: juniper@123
+  ...
+  ```
+Tips: If somecases we don't have an unique account for all ILO/IDRAC, we can define more file with: <name>.yml same with sample.yml that I defined, then we can add other account and use prometheus query with parameter: config: <name>. Check `Pull metrics from Redfish Exporter` or `Query metrics for testing` section
+
 #### Create Exporter
 There're two ways that you can use Redfish-Exporter:
 * Using Container Images:
@@ -43,7 +57,7 @@ There're two ways that you can use Redfish-Exporter:
     templates/
     |-- configs
     |   |-- inventory.yml                            ### Define devices that need for collecting, you can check example
-    |   |-- sample.yml                               ### Define metrics using for prometheus metrics
+    |   |-- sample.yml                               ### Define Auth (Using Readonly ILO/IDRAC Account) - Metrics (Using to define prometheus metrics)
     |-- schemas
         |-- Common.yml                               ### Schema that get common information for all vendor server (of course with Redfish DMTF supporting)
         |-- DellPowerEdgeR630.yml                    ### Schema that get vendor information
@@ -71,8 +85,6 @@ You need to have Prometheus Server or Victoria Metrics or else, change configura
       params:
         serverAddress: ['<server-idrac-or-ilo-ip>']
         config: ['sample']
-	username: ['<username>']
-	password: ['<password>']
       static_configs:
       - targets: ["<exporter-ip>:9814"]
     ```
@@ -111,7 +123,7 @@ You can use `curl` command to query server for testing data:
 * For example:
 
     ```bash
-    curl -XGET 'http://<exporter-ip>:<exporter-port>/metrics?serverAddress=<server-ip>&config=<file name in config dir>'&username=<username login server>&password=<password login server>
+    curl -XGET 'http://<exporter-ip>:<exporter-port>/metrics?serverAddress=<server-ip>&config=<file name in config dir>'
     ```
 
 Other way you can connect to FastAPI doc WebUI:

--- a/src/redfish_collector/core/dataReconstruction.py
+++ b/src/redfish_collector/core/dataReconstruction.py
@@ -28,7 +28,7 @@ def dataReconstructor(dataRaw,dataNewSchema, templateDir, serverAddress,logLevel
     # logFormat = '%(asctime)s [%(levelname)s] %(message)s'
     # logging.basicConfig(format=logFormat, level=logLevel.upper())
     cleaned_data=dataRaw
-    notUseValueList = ['@odata','Oem']
+    notUseValueList = ['@odata']
     for notUseValue in notUseValueList:
         cleaned_data = remove_odata_elements(cleaned_data,notUseValue)
     # return cleaned_data

--- a/src/redfish_collector/core/generator.py
+++ b/src/redfish_collector/core/generator.py
@@ -18,10 +18,12 @@ def redfishCollector(serverAddress,username,password):
     try:
         dataRaw, dataNewSchema, modelSchemaDir = asyncio.run(dataCollector(serverAddress,username,password,templateDir,logLevel))
         dataReconstructor(dataRaw, dataNewSchema, modelSchemaDir, serverAddress,logLevel)
+        return
     except Exception as err:
         logging.error("[%s] Tried collecting data failed: %s" %(serverAddress,err))
-    # logging.info("Generate finished")
-    return
+        with open('%sNewData/%s.json' % (REDFISH_DATA, serverAddress), 'w') as f:
+            pass
+        raise
 
 def generatorMultiThreading():
     while True:

--- a/src/redfish_collector/core/rawCollector.py
+++ b/src/redfish_collector/core/rawCollector.py
@@ -51,12 +51,13 @@ def dataJSONWriter(dataRaw,fileDir,fileName, serverAddress):
             json.dump(dataRaw, file)
         logging.info("[%s] Write data successfully at %s%s" % (serverAddress,fileDir,fileName))
     except Exception as e:
-        logging.error("[%s] There error with %s" % (serverAddress,e))
+        logging.error("[%s] There dataJSONWriter error with %s" % (serverAddress,e))
+        json.dump([],file)
     return
 
 async def fetch(url,username,password, session,serverAddress):
     auth = BasicAuth(username,password)
-    retries=3
+    retries=5
     backoffFactor=0.5
     for attempt in range(1,retries+1):
         try:
@@ -84,7 +85,8 @@ async def fetch_all(urls: list(),username,password,serverAddress):
             results = await asyncio.gather(*tasks)
             return results
     except Exception as e:
-        logging.error("[%s] There error with %s" % (serverAddress,e))
+        logging.error("[%s] There fetch_all error with %s" % (serverAddress,e))
+        raise
 
 async def rawDataCollector(serverAddress,schemaContent,keyDict: dict,username,password,logLevel):
     logFormat = '%(asctime)s [%(levelname)s] %(message)s'
@@ -118,6 +120,7 @@ async def rawDataCollector(serverAddress,schemaContent,keyDict: dict,username,pa
             # logging.info(childURIList)
             if childURIList is False:
                 logging.warning("[%s] Child URI List isn't existed" % serverAddress)
+                logging.error("[%s] childURIList:\n%s" % (serverAddress,tempRaw))
                 return
             childURLList = ["https://%s%s" % (serverAddress,path) for path in childURIList]
             dataRawList = await fetch_all(childURLList,username,password,serverAddress)

--- a/src/redfish_collector/core/templates/configs/inventory.yml
+++ b/src/redfish_collector/core/templates/configs/inventory.yml
@@ -1,9 +1,0 @@
-- serverAddress: 10.97.12.1
-  username: readonly
-  password: juniper@123
-- serverAddress: 10.97.12.2
-  username: readonly
-  password: juniper@123
-- serverAddress: 10.97.12.3
-  username: readonly
-  password: juniper@123

--- a/src/redfish_collector/core/templates/configs/sample.yml
+++ b/src/redfish_collector/core/templates/configs/sample.yml
@@ -1,3 +1,6 @@
+Auth:
+  Username: readonly
+  Password: juniper@123
 Metrics:
   - Name: PhysicalServer_State
     Description: 'physical server state status'
@@ -157,15 +160,29 @@ Metrics:
       GOODINUSE: 0
       UNKNOWN: 99
       ABSENT: 2
-  # - Name: PhysicalServer_powerControlStatus
-  #   Description: 'physical server power control status'
-  #   Type: Gauge
-  #   Label: ["ServerAddress","HostName","PowerCapacityWatts","PowerLimitWatts","AverageConsumedWatts"]
-  #   Datapoint: PowerControl
-  #   Result: PowerConsumedWatts
-  # - Name: PhysicalServer_temperatureValue
-  #   Description: 'physical server temperature value'
-  #   Type: Gauge
-  #   Label: ["ServerAddress","HostName","Name"]
-  #   Datapoint: Temperature
-  #   Result: ReadingCelsius
+  - Name: PhysicalServer_LastPowerOutputWatts
+    Description: 'physical server power supplie status'
+    Type: Gauge
+    Label: ["ServerAddress","HostName","Model","LineInputVoltage","LineInputVoltageType","PowerSupplyType","PowerOutputWatts","PowerCapacityWatts","Manufacturer","SerialNumber"]
+    Datapoint: Power.PowerSupplies
+    Result: LastPowerOutputWatts
+  - Name: PhysicalServer_CPUUtilizationPercent
+    Description: 'physical server cpu utilization percent'
+    Type: Gauge
+    Label: ["ServerAddress","HostName"]
+    Datapoint: Common
+    Result: CPUUtil  
+  - Name: PhysicalServer_JitterCount
+    Description: 'physical server jitter count'
+    Type: Gauge
+    Label: ["ServerAddress","HostName"]
+    Datapoint: Common
+    Result: JitterCount
+  - Name: PhysicalServer_MemoryBusUtilPercent
+    Description: 'physical server memory bus utilization percent'
+    Type: Gauge
+    Label: ["ServerAddress","HostName"]
+    Datapoint: Common
+    Result: MemoryBusUtil
+  
+  

--- a/src/redfish_collector/core/templates/schemas/HPEProLiantGen10.yml
+++ b/src/redfish_collector/core/templates/schemas/HPEProLiantGen10.yml
@@ -46,6 +46,13 @@ Data:
     Status: Status
     SystemType: SystemType
     UUID: UUID
+    AvgCPU0Freq: Oem.Hpe.SystemUsage.AvgCPU0Freq
+    CPU0Power: Oem.Hpe.SystemUsage.CPU0Power
+    CPUICUtil: Oem.Hpe.SystemUsage.CPUICUtil
+    CPUUtil: Oem.Hpe.SystemUsage.CPUUtil
+    IOBusUtil: Oem.Hpe.SystemUsage.IOBusUtil
+    JitterCount: Oem.Hpe.SystemUsage.JitterCount
+    MemoryBusUtil: Oem.Hpe.SystemUsage.MemoryBusUtil
   ArrayController:
     Id: $.ArrayController[*].Id
     AdapterType: AdapterType

--- a/src/redfish_collector/core/templates/schemas/HPEProLiantGen11.yml
+++ b/src/redfish_collector/core/templates/schemas/HPEProLiantGen11.yml
@@ -46,6 +46,13 @@ Data:
     Status: Status
     SystemType: SystemType
     UUID: UUID
+    AvgCPU0Freq: Oem.Hpe.SystemUsage.AvgCPU0Freq
+    CPU0Power: Oem.Hpe.SystemUsage.CPU0Power
+    CPUICUtil: Oem.Hpe.SystemUsage.CPUICUtil
+    CPUUtil: Oem.Hpe.SystemUsage.CPUUtil
+    IOBusUtil: Oem.Hpe.SystemUsage.IOBusUtil
+    JitterCount: Oem.Hpe.SystemUsage.JitterCount
+    MemoryBusUtil: Oem.Hpe.SystemUsage.MemoryBusUtil
   ArrayController:
     Id: $.ArrayController[*].Id
     AdapterType: AdapterType

--- a/src/redfish_collector/routers/prometheus.py
+++ b/src/redfish_collector/routers/prometheus.py
@@ -34,10 +34,11 @@ router = APIRouter(
 
 @router.get("", status_code=status.HTTP_200_OK)
 async def read_all(serverAddress: IPvAnyAddress = Query(None), \
-                    username: str = Query(None), \
-                    password: str = Query(None), \
+                    # username: str = Query(None), \
+                    # password: str = Query(None), \
                     config: str = Query(None)):
-    if (serverAddress is None) or (config is None) or (username is None) or (password is None):
+    # if (serverAddress is None) or (config is None) or (username is None) or (password is None):
+    if (serverAddress is None) or (config is None):
     # if (serverAddress is None) or (config is None):
         raise HTTPException(status_code=401, detail = 'Collect metrics Failed, please add params')
 
@@ -45,10 +46,25 @@ async def read_all(serverAddress: IPvAnyAddress = Query(None), \
     else:
         inventoryFile = REDFISH_DATA + 'inventory.yml'
         try:
+            metricsConfigFile = templateDir + "configs/" + config + ".yml"
+            metricsConfig = readYAMLTemplate(metricsConfigFile)
+            if "Auth" in metricsConfig:
+                username = metricsConfig['Auth']['Username']
+                password = metricsConfig['Auth']['Password']
+            else:
+                logging.error("[%s] Can't find Auth in config file %s" % (serverAddress,config))
+                return False
+            cacheInfo="%s%s" % (serverAddress,config)
+            if cacheInfo in CACHE:
+                cachedResponse, timestamp = CACHE[cacheInfo]
+                if time.time() - timestamp < int(60):
+                    logging.info("[%s] Complete gathering health-check information from cache (1 minute cache to avoid DOS)" %serverAddress)
+                    return PlainTextResponse(cachedResponse)
+
             with open(inventoryFile, 'r') as f:
                 yamlContent = f.read()
                 inventory = yaml.safe_load(yamlContent)
-            block = {'serverAddress': str(serverAddress),'username': str(username),'password': str(password),'timeCalled': time.time()}
+            block = {'serverAddress': str(serverAddress), 'username': str(username), 'password': str(password) ,'timeCalled': time.time()}
             if not inventory:
                 with open('%sinventory.yml' %REDFISH_DATA, 'w') as f:
                     yaml.dump([block], f, default_flow_style=False)
@@ -70,13 +86,6 @@ async def read_all(serverAddress: IPvAnyAddress = Query(None), \
             logging.error("Generate instance failed: %s" %err)
             return False
 
-    cacheInfo="%s%s" % (serverAddress,config)
-    if cacheInfo in CACHE:
-        cachedResponse, timestamp = CACHE[cacheInfo]
-        if time.time() - timestamp < int(45):
-            logging.info("[%s] Complete gathering health-check information from cache" %serverAddress)
-            return PlainTextResponse(cachedResponse)
-
     try:
         start_time = time.time()
         dataDir = '/tmp/redfish-data/NewData/%s.json' %serverAddress 
@@ -87,9 +96,6 @@ async def read_all(serverAddress: IPvAnyAddress = Query(None), \
             # return data
 
         hostName = collectedData['Common'][0]['HostName']
-        metricsConfigFile = templateDir + "configs/" + config + ".yml"
-        # logging.info("Metrics file: %s" %metricsConfigFile)
-        metricsConfig = readYAMLTemplate(metricsConfigFile)
         registry = CollectorRegistry()
         componentMetrics={}
         for metric in metricsConfig['Metrics']:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring fields for CPU frequency, CPU power, CPU/IO/memory bus utilization and jitter count for HPE ProLiant Gen10/Gen11; new corresponding metrics added to sample config.

* **Bug Fixes / Reliability**
  * Improved error handling and retry behavior; writes safe placeholders on collection failures and logs richer diagnostics.

* **Configuration / Docs**
  * Introduced an Auth section for readonly iLO/iDRAC accounts, removed embedded credentials from examples, updated README usage and testing steps.

* **Performance**
  * Prometheus endpoint now uses config-sourced auth and per-config caching to reduce repeated processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->