### PR TITLE
readYAMLTemplate: add serverAddress to function

### DIFF
--- a/src/redfish_collector/core/rawCollector.py
+++ b/src/redfish_collector/core/rawCollector.py
@@ -13,7 +13,7 @@ from aiohttp import ClientConnectorError, ClientResponseError, ClientTimeout, Cl
 
 
 
-def readYAMLTemplate(templateFile):
+def readYAMLTemplate(templateFile, serverAddress):
     config_file_path = path.join(path.dirname(__file__), templateFile)
     if path.isfile(config_file_path):
         with open(templateFile, 'r') as f:
@@ -171,7 +171,7 @@ async def dataCollector(serverAddress,username,password,templateDir,logLevel):
     # auth = (username,password)
     base = templateDir + "schemas/Common.yml"
     # base = templateDir + "schemas/HPEProLiantGen10.yml"
-    commonSchema=readYAMLTemplate(base)
+    commonSchema=readYAMLTemplate(base, serverAddress)
     if commonSchema is None:
         logging.error("[%s] Can't generate common schema, please check again" % serverAddress)
         return
@@ -256,7 +256,7 @@ async def dataCollector(serverAddress,username,password,templateDir,logLevel):
 
     # logging.info(vendorData)
     modelSchemaDir = templateDir + "schemas/" + modelSchema
-    schema=readYAMLTemplate(modelSchemaDir)
+    schema=readYAMLTemplate(modelSchemaDir, serverAddress)
     # logging.info(schema)
     dataNewSchema = schema['Data']
     if schema is None:

--- a/src/redfish_collector/routers/prometheus.py
+++ b/src/redfish_collector/routers/prometheus.py
@@ -36,7 +36,7 @@ async def read_all(serverAddress: IPvAnyAddress = Query(None), config: str = Que
             makedirs(REDFISH_DATA)
         try:
             metricsConfigFile = f'{templateDir}configs/{config}.yml'
-            metricsConfig = readYAMLTemplate(metricsConfigFile)
+            metricsConfig = readYAMLTemplate(metricsConfigFile, serverAddress)
             if "Auth" not in metricsConfig:
                 logging.error(f"[{serverAddress}] Can't find Auth in config file {config}")
                 componentMetrics['PhysicalServer_Query'].labels(str(serverAddress)).set(0)


### PR DESCRIPTION
When deploying the solution, I faced a human error:
```
redfish_exporter_hw_DELTA_44  | 2025-12-29 16:22:57,425 [ERROR] [10.200.17.1] Metric collection failed: name 'serverAddress' is not defined
redfish_exporter_hw_DELTA_44  | Traceback (most recent call last):
redfish_exporter_hw_DELTA_44  |   File "/usr/local/lib/python3.12/site-packages/redfish_collector/routers/prometheus.py", line 39, in read_all
redfish_exporter_hw_DELTA_44  |     metricsConfig = readYAMLTemplate(metricsConfigFile)
redfish_exporter_hw_DELTA_44  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
redfish_exporter_hw_DELTA_44  |   File "/usr/local/lib/python3.12/site-packages/redfish_collector/core/rawCollector.py", line 25, in readYAMLTemplate
redfish_exporter_hw_DELTA_44  |     logging.error("[%s] Can not find: %s" % (serverAddress,templateFile))
redfish_exporter_hw_DELTA_44  |                                              ^^^^^^^^^^^^^
redfish_exporter_hw_DELTA_44  | NameError: name 'serverAddress' is not defined
```

I was doing a wrong curl because I was not ont he yaml file I was supposed to get but the error was like if the `serverAddress` was not right.

The logging error could not be achieved because the variable was undefined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting to include server-specific context when a template or metrics configuration cannot be loaded, enabling clearer diagnostics.
  * Ensured metrics configuration loading now associates failures with the correct server for more actionable logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->