### PR TITLE
Server model can be an integer for some equipments

### DIFF
--- a/src/redfish_collector/core/rawCollector.py
+++ b/src/redfish_collector/core/rawCollector.py
@@ -240,9 +240,7 @@ async def dataCollector(serverAddress,username,password,templateDir,logLevel):
         if i in manufacturer:
             logging.info("[%s] This's %s Server - Founded Vendor Name %s" % (serverAddress,i,manufacturer))
             for j in commonSchema['ModelSchema'][i]:
-                # Enforce model to string
-                j = str(j)
-                if j in model:
+                if str(j) in str(model):
                     logging.info("[%s] Model using %s - Founded Model Name %s" % (serverAddress,j,model))
                     modelSchema = commonSchema['ModelSchema'][i][j]
                     break

--- a/src/redfish_collector/core/rawCollector.py
+++ b/src/redfish_collector/core/rawCollector.py
@@ -240,6 +240,8 @@ async def dataCollector(serverAddress,username,password,templateDir,logLevel):
         if i in manufacturer:
             logging.info("[%s] This's %s Server - Founded Vendor Name %s" % (serverAddress,i,manufacturer))
             for j in commonSchema['ModelSchema'][i]:
+                # Enforce model to string
+                j = str(j)
                 if j in model:
                     logging.info("[%s] Model using %s - Founded Model Name %s" % (serverAddress,j,model))
                     modelSchema = commonSchema['ModelSchema'][i][j]


### PR DESCRIPTION
Here is a use case I did find.

In my case, a DELTA power shelf which shows, in RedFish as:
```
"Manufacturer": "DELTA",
"Model": "44",
```

So the ModelSchema is like:
```
ModelSchema:
  DELTA:
    44: hw_DELTA_44.yml
```

But when doing so, the python codes states:
```
redfish_exporter_hw_DELTA_44  | 2025-12-29 16:37:59,839 [ERROR] [10.200.17.1] Metric collection failed: 'in <string>' requires string as left operand, not int
redfish_exporter_hw_DELTA_44  | Traceback (most recent call last):
redfish_exporter_hw_DELTA_44  |   File "/usr/local/lib/python3.12/site-packages/redfish_collector/routers/prometheus.py", line 62, in read_all
redfish_exporter_hw_DELTA_44  |     dataRaw, dataNewSchema, modelSchemaDir = await dataCollector(serverAddress,username,password,templateDir,loglevel)
redfish_exporter_hw_DELTA_44  |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
redfish_exporter_hw_DELTA_44  |   File "/usr/local/lib/python3.12/site-packages/redfish_collector/core/rawCollector.py", line 243, in dataCollector
redfish_exporter_hw_DELTA_44  |     if j in model:
redfish_exporter_hw_DELTA_44  |        ^^^^^^^^^^
redfish_exporter_hw_DELTA_44  | TypeError: 'in <string>' requires string as left operand, not int
```

I just enforce the model the be converted to a string to avoid this here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of model keys so non-string keys are recognized when represented as text, ensuring correct model selection during processing. This reduces mismatches and improves data processing reliability and consistency for affected workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->